### PR TITLE
UNRW-632: Allow calendar dropdown to always be visible.

### DIFF
--- a/source/scss/components/organisms/_timeline-widget.scss
+++ b/source/scss/components/organisms/_timeline-widget.scss
@@ -222,9 +222,7 @@
       left: 0;
 
       @include breakpoint($bp--timeline-2col) {
-        @include arrow($color--purple--dark, left);
-        top: em(16px);
-        left: em(16px);
+        display: none;
       }
     }
   }


### PR DESCRIPTION
Per David Spira this ticket is just to remove the calendar dropdown interaction on Desktop. It is currently setup to always be visible while it Desktop view. The new design will be completed in another ticket.
